### PR TITLE
Two minor modifications

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,6 +34,7 @@ register_sidebar( array(
 ));
 
 //Enqueue_styles
+if ( ! function_exists( 'Wps_load_styles' ) ) {
 function Wps_load_styles() {
 
 	wp_register_style( 'skeleton-style', get_template_directory_uri() . '/style.css');
@@ -46,3 +47,4 @@ function Wps_load_styles() {
 
 }
 add_action('wp_enqueue_scripts', 'Wps_load_styles');
+} // endif

--- a/style.css
+++ b/style.css
@@ -30,10 +30,6 @@ Use it to make something cool, have fun, and share what you've learned with othe
     /*.column, .columns                           { float: left; display: inline;}*/
     .row                                        { margin-bottom: 20px; }
 
-    /* Nested Column Classes */
-    .column.alpha, .columns.alpha               { margin-left: 0; }
-    .column.omega, .columns.omega               { margin-right: 0; }
-
     /* Base Grid */
     .container .one.column                      { width: 40px;  }
     .container .two.columns                     { width: 100px; }
@@ -72,11 +68,12 @@ Use it to make something cool, have fun, and share what you've learned with othe
     .container .offset-by-fourteen              { padding-left: 840px; }
     .container .offset-by-fifteen               { padding-left: 900px; }
 
-
+    /* Nested Column Classes */
+    .column.alpha, .columns.alpha               { margin-left: 0; }
+    .column.omega, .columns.omega               { margin-right: 0; }
+	
         /* WordPress sidebar*/
-        .one-third.column{
-          margin-left: 30px;
-        }
+       #side .one-third.column{ margin-left: 30px; }
         
 
 /* #Tablet (Portrait)


### PR DESCRIPTION
I like to work with parent and child themes.  The change to the functions file allows a child theme to override a Skeleton parent file.

The edit to the style.css allows the one-third and two thirds columns to be used throughout WordPress.  Without the id, the third widths cannot be used.
